### PR TITLE
Added test stuff

### DIFF
--- a/Test.hs
+++ b/Test.hs
@@ -1,0 +1,73 @@
+module Main where
+
+import Data.List
+import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty.QuickCheck
+import Test.QuickCheck
+import MMAlgoA
+import ReadPrintTerms
+
+instance Arbitrary Term where
+  arbitrary = do
+    Positive size <- arbitrary
+    sizedTerm (size `mod` 1000)
+
+sizedTerm :: Int -> Gen Term
+sizedTerm n = do
+  name <- return "" --arbitrary
+  i    <- arbitrary
+  args <- sizedListOf sizedTerm (n - 1)
+  elements ([Constant name, Variable name] ++
+            if n < 2 then []
+                     else [Function name i args])
+
+-- Given a size s, generates a list where the sizes of the elements sum to <= s
+sizedListOf :: (Int -> Gen a) -> Int -> Gen [a]
+sizedListOf g s = do
+  ns <- listOf (choose (0, s))        -- Generate random points between 0 and s
+  let points = sort (take s ns)       -- Sort them
+      sizes  = diffsBetween 0 points  -- Get the distances between them
+  mapM g (filter (> 0) sizes)         -- Use the distances as element sizes
+  where diffsBetween n []     = []
+        diffsBetween n (x:xs) = (x-n) : diffsBetween x xs
+
+sizedListRespectsBound (NonNegative n) =
+  forAll (sizedListOf (return :: Int -> Gen Int) n) sumBounded
+  where sumBounded ns = sum ns <= n
+
+sizedTermRespectsBound (NonNegative n) =
+  forAll (sizedTerm n) termBounded
+  where termBounded t = termSize t <= n + 1
+        termSize (Function _ _ ts) = 1 + sum (map termSize ts)
+        termSize _                 = 1
+
+functionContainingVar :: Term -> Gen Term
+functionContainingVar v = do
+  name <- arbitrary
+  pre  <- arbitrary
+  post <- arbitrary
+  preContaining  <- listOf (functionContainingVar v)
+  postContaining <- listOf (functionContainingVar v)
+  return (Function name 1 (preContaining ++ pre ++ [v] ++ post ++ postContaining))
+
+sameTermsUnify t =
+  unificationTransform [(t, t)] /= Nothing
+
+differentConstantsDontUnify c1 c2 = c1 /= c2 ==>
+  unificationTransform [(Constant c1, Constant c2)] == Nothing
+
+differentConstantAndFunctionDontUnify c1 f1 i l = c1 /= f1 ==>
+  unificationTransform [(Constant c1, Function f1 i l)] == Nothing
+
+functionWithArgumentsWontUnifyWithConstant n i l =
+  unificationTransform [(Constant n, Function n positive l)] == Nothing
+  where positive = 1 + (abs i)
+
+main = defaultMain $ testGroup "All tests" [
+    testProperty "Can generate bounded lists" sizedListRespectsBound
+  , testProperty "Can generate bounded terms" sizedTermRespectsBound
+  , testProperty "Different Constants Don't Unify" differentConstantsDontUnify
+  , testProperty "Same terms unify" sameTermsUnify
+  , testProperty "Differently named constants/functions don't unify" differentConstantAndFunctionDontUnify
+  , testProperty "Function with arguments won't unify with constant" functionWithArgumentsWontUnifyWithConstant
+  ]

--- a/unification.cabal
+++ b/unification.cabal
@@ -19,6 +19,14 @@ library
   exposed-modules:     UnifyTerms, Substitution, ReadPrintTerms, MMAlgoA, FOTEset
   other-modules:       
   other-extensions:    
-  build-depends:       base >=4.7 && <4.8
+  build-depends:       base >=4.7
   hs-source-dirs:      
   default-language:    Haskell2010
+
+test-suite test
+    type:                exitcode-stdio-1.0
+    main-is:             Test.hs
+    build-depends:       base >=4.7
+                       , tasty >= 0.7
+                       , tasty-quickcheck
+                       , QuickCheck


### PR DESCRIPTION
Here are some tests to get you started. They should be runnable using `cabal test`, although you may need to run `cabal configure` first.

I've included an Arbitrary Term instance which doesn't suffer the 'infinite recursion' problem (it picks a random number, then passes it along through recursive calls).

For generating unifyable terms, I would do something like this:

```
newtype UnifyingPair = UP Term Term

instance Arbitrary UnifyingPair where
  arbitrary = ....
```

For the "arbitrary" method, I'd have it choose randomly between a few different branches:
- Some generate terms which can obviously unify, eg. a pair of the same term, a random term and a variable, etc.
- Some generate a pair of unifiable terms, then alter them in a way that they're still unifiable, eg. wrapping both in the same function

There's loads of information on QuickCheck if you Google around. Here's a few helpful pages:
- https://hackage.haskell.org/package/QuickCheck-2.8.1/docs/Test-QuickCheck.html
- https://www.fpcomplete.com/user/pbv/an-introduction-to-quickcheck-testing
- http://www.cse.chalmers.se/~rjmh/QuickCheck/manual.html
- http://jaspervdj.be/posts/2015-03-13-practical-testing-in-haskell.html

Lots of information on Tasty (options, etc.) is at http://documentup.com/feuerbach/tasty
